### PR TITLE
Fix library usage as a cmake sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.16)
 
 project(elite-cs-series-sdk VERSION 1.1.0)
 
+option(ELITE_COMPLIE_TESTS "Compile tests" ON)
+option(ELITE_COMPLIE_DOC "Compile documentation" OFF)
+option(ELITE_COMPLIE_EXAMPLES "Compile examples" OFF)
+
 include(cmake/utils.cmake)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
@@ -25,7 +29,7 @@ if(NOT BOOST_FOUND)
 endif()
 
 configure_file(
-    ${CMAKE_SOURCE_DIR}/include/EliteOptions.hpp.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/EliteOptions.hpp.in
     ${PROJECT_BINARY_DIR}/include/Elite/EliteOptions.hpp
 )
 
@@ -126,6 +130,20 @@ file(COPY ${PROJECT_SOURCE_DIR}/include/EliteException.hpp DESTINATION ${PROJECT
 file(COPY ${PROJECT_SOURCE_DIR}/include/Elite/EliteDriver.hpp DESTINATION ${PROJECT_BINARY_DIR}/include/Elite)
 file(COPY ${PROJECT_SOURCE_DIR}/include/Elite/Log.hpp DESTINATION ${PROJECT_BINARY_DIR}/include/Elite)
 
+# Prepare exporting targets
+add_library(${PROJECT_NAME}::shared ALIAS ${PROJECT_NAME}_SHARED)
+target_include_directories(
+    ${PROJECT_NAME}_SHARED
+    INTERFACE
+    "${PROJECT_BINARY_DIR}/include"
+)
+add_library(${PROJECT_NAME}::static ALIAS ${PROJECT_NAME}_STATIC)
+target_include_directories(
+    ${PROJECT_NAME}_STATIC
+    INTERFACE
+    "${PROJECT_BINARY_DIR}/include"
+)
+
 # Is compile examples
 if(ELITE_COMPLIE_EXAMPLES)
     message(STATUS "Compile the exmaples")
@@ -139,13 +157,17 @@ if(ELITE_COMPLIE_DOC)
 endif()
 
 # If googel test has been foune, compile unit test
-if (GTEST_FOUND)
+if (GTEST_FOUND AND ELITE_COMPLIE_TESTS)
     message(STATUS "Compile the tests")
     add_subdirectory(test ${CMAKE_BINARY_DIR}/test/)
 endif()
 
+# Disable installation if project imported with FetchContent
+string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" is_top_level)
+option(ELITE_INSTALL "Include packaging rules" "${is_top_level}")
+
 # On the Linux platform, install binary library files, header files, and CMake configuration files.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND ELITE_INSTALL)
     include(GNUInstallDirs)
     install(
         TARGETS ${PROJECT_NAME}_SHARED ${PROJECT_NAME}_STATIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,14 +134,16 @@ file(COPY ${PROJECT_SOURCE_DIR}/include/Elite/Log.hpp DESTINATION ${PROJECT_BINA
 add_library(${PROJECT_NAME}::shared ALIAS ${PROJECT_NAME}_SHARED)
 target_include_directories(
     ${PROJECT_NAME}_SHARED
-    INTERFACE
-    "${PROJECT_BINARY_DIR}/include"
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>  
+    $<INSTALL_INTERFACE:include>
 )
 add_library(${PROJECT_NAME}::static ALIAS ${PROJECT_NAME}_STATIC)
 target_include_directories(
     ${PROJECT_NAME}_STATIC
-    INTERFACE
-    "${PROJECT_BINARY_DIR}/include"
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>  
+    $<INSTALL_INTERFACE:include>
 )
 
 # Is compile examples

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,22 +13,14 @@ endif()
 foreach(SOURCE ${SOURCES})
     get_filename_component(ELITE_SDK_EXAMPLE_NAME ${SOURCE} NAME_WE)
     add_executable(${ELITE_SDK_EXAMPLE_NAME} ${SOURCE})
-    target_include_directories(
-        ${ELITE_SDK_EXAMPLE_NAME} 
-        PUBLIC 
-        ${CMAKE_BINARY_DIR}/include
-    )
     target_link_libraries(
         ${ELITE_SDK_EXAMPLE_NAME} 
-        elite-cs-series-sdk
+        elite-cs-series-sdk::shared
         ${SYSTEM_LIB}
     )
     target_link_directories(
         ${ELITE_SDK_EXAMPLE_NAME} 
         PRIVATE ${CMAKE_BINARY_DIR}
-    )
-    add_dependencies(
-        ${ELITE_SDK_EXAMPLE_NAME} ${PROJECT_NAME}_SHARED
     )
 endforeach()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,6 @@ foreach(SOURCE ${SOURCES})
     target_include_directories(
         ${ELITE_SDK_TEST_NAME} 
         PUBLIC
-        ${CMAKE_BINARY_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/
         ${PROJECT_SOURCE_DIR}/include/Common
         ${PROJECT_SOURCE_DIR}/include/Elite
@@ -19,15 +18,12 @@ foreach(SOURCE ${SOURCES})
     )
     target_link_libraries(
         ${ELITE_SDK_TEST_NAME}
-        elite-cs-series-sdk
+        elite-cs-series-sdk::shared
         gtest
         pthread
     )
     target_link_directories(
         ${ELITE_SDK_TEST_NAME} 
         PRIVATE ${CMAKE_BINARY_DIR}
-    )
-    add_dependencies(
-        ${ELITE_SDK_TEST_NAME} ${PROJECT_NAME}_SHARED
     )
 endforeach()


### PR DESCRIPTION
Hello,
This pull request presents cmake fixes which make possible to use your project as a sub-module.
There are two general techniques for that:
- [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
- [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html)

In both cases, there was a lack of aliased target and public includes baked in them.

I have committed necessary changes to make the process of adding this library simpler:
- Declare options at the top and make possible to disable unnecessary target via them
- Add aliases to library targets
- Add public headers to library targets
- Change CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR
- Disable install directives if project is added via FetchContent

Now, what it gives:
```cmake
FetchContent_Declare(
    elite-cs-series-sdk
    GIT_REPOSITORY https://github.com/Elite-Robots/Elite_Robots_CS_SDK.git
    GIT_TAG main
    GIT_SHALLOW ON
)

set(ELITE_COMPLIE_EXAMPLES OFF CACHE INTERNAL "")
set(ELITE_COMPLIE_DOC OFF CACHE INTERNAL "")
set(ELITE_COMPLIE_TESTS OFF CACHE INTERNAL "")
FetchContent_MakeAvailable(elite-cs-series-sdk)

add_executable(your_client_app *.cpp)
target_link_libraries(your_client_app
    elite-cs-series-sdk::static)
```

No additional target_include_directories or add_dependencies are required. It is done implicitly by the cmake.