### PR TITLE
Fix header file lacks declarations to prevent duplicate definitions

### DIFF
--- a/include/Elite/RemoteUpgrade.hpp
+++ b/include/Elite/RemoteUpgrade.hpp
@@ -1,3 +1,7 @@
+#ifndef __ELITE__REMOTE_UPGRADE_HPP__
+#define __ELITE__REMOTE_UPGRADE_HPP__
+
+
 #include <string>
 
 namespace ELITE
@@ -21,3 +25,5 @@ bool upgradeControlSoftware(std::string ip, std::string file, std::string passwo
 
 }
 }
+
+#endif


### PR DESCRIPTION
Fix the issue that the `RemoteUpgrade.hpp` header file lacks declarations to prevent duplicate definitions.