### PR TITLE
Fix writeJointCommand, expose recipe getter/setter

### DIFF
--- a/include/Rtsi/RtsiIOInterface.hpp
+++ b/include/Rtsi/RtsiIOInterface.hpp
@@ -429,6 +429,27 @@ public:
      */
     ELITE_EXPORT double getOutDoubleRegister(int index);
 
+    /**
+     * @brief Get data from output recipe
+     * 
+     * @tparam T data type
+     * @param name Variable name
+     * @param out_value Output value
+     */
+     template<typename T>
+     ELITE_EXPORT void getRecipeValue(const std::string& name, T& out_value);
+ 
+     /**
+      * @brief Set the input recipe value
+      * 
+      * @tparam T data type
+      * @param name Variable name
+      * @param value Set value
+      * @return false fail
+      */
+     template<typename T>
+     ELITE_EXPORT bool setInputRecipeValue(const std::string &name, const T& value);
+
 private:
     volatile bool input_new_cmd_;
     std::vector<std::string> input_recipe_string_;
@@ -461,27 +482,6 @@ private:
      * @return std::vector<std::string> The field for the subscription item
      */
     std::vector<std::string> readRecipe(const std::string& file);
-
-    /**
-     * @brief Get data from output recipe
-     * 
-     * @tparam T data type
-     * @param name Variable name
-     * @param out_value Output value
-     */
-    template<typename T>
-    void getRecipeValue(const std::string& name, T& out_value);
-
-    /**
-     * @brief Set the input recipe value
-     * 
-     * @tparam T data type
-     * @param name Variable name
-     * @param value Set value
-     * @return false fail
-     */
-    template<typename T>
-    bool setInputRecipeValue(const std::string &name, const T& value);
 
 };
 

--- a/source/Control/ReverseInterface.cpp
+++ b/source/Control/ReverseInterface.cpp
@@ -70,7 +70,7 @@ bool ReverseInterface::writeJointCommand(const vector6d_t* pos, ControlMode mode
     data[REVERSE_DATA_SIZE - 1] = htonl((int)mode);
     if (pos) {
         for (size_t i = 0; i < 6; i++) {
-            data[i + 1] = htonl(round((*pos)[i] * CONTROL::POS_ZOOM_RATIO));
+            data[i + 1] = htonl(static_cast<int>(round((*pos)[i] * CONTROL::POS_ZOOM_RATIO)));
         }
     }
     


### PR DESCRIPTION
Hello,
This PR is based on servoj command testing.

I have found a bug with implicit cast of `double` to `uint32_t` (8 bytes to 4) on g++-11, which is not reproducing on g++-13 and higher.

The second change is about exposing RTSI inputs setter and outputs getter, with this change I've managed to control the arm with RTSI-only connection and use additional registers for a gripper control.
