### PR TITLE
Optimize the 30001 port interface

### DIFF
--- a/doc/API/cn/RobotException.cn.md
+++ b/doc/API/cn/RobotException.cn.md
@@ -22,11 +22,13 @@
 
 ```cpp
 enum class Type : int8_t {
+    ROBOT_TCP_DISCONNECTED = -1
     ROBOT_ERROR = 6,
     SCRIPT_RUNTIME = 10
 };
 ```
 
+* `ROBOT_TCP_DISCONNECTED` : 表示与机器人断开了连接
 * `ROBOT_ERROR`：表示机器人运行错误。
 * `SCRIPT_RUNTIME`：表示运行时异常，如语法错误、脚本执行错误等。
 

--- a/doc/API/en/RobotException.en.md
+++ b/doc/API/en/RobotException.en.md
@@ -22,11 +22,13 @@ The base class for robot exceptions, representing common exception properties su
 
 ```cpp
 enum class Type : int8_t {
+    ROBOT_TCP_DISCONNECTED = -1
     ROBOT_ERROR = 6,
     SCRIPT_RUNTIME = 10
 };
 ```
 
+* `ROBOT_TCP_DISCONNECTED` : Represents a disconnection from the robot.
 * `ROBOT_ERROR`: Represents a robot operation error.
 * `SCRIPT_RUNTIME`: Represents a runtime error, such as script execution or syntax issues.
 

--- a/include/Elite/RobotException.hpp
+++ b/include/Elite/RobotException.hpp
@@ -22,8 +22,9 @@ class RobotException {
    public:
     // Exception Type
     enum class Type : int8_t {
-        ROBOT_ERROR = 6,    // Represents a robot operation error.
-        SCRIPT_RUNTIME = 10  // Represents a runtime error, such as script execution or syntax issues.
+        ROBOT_DISCONNECTED = -1,  // Represents a disconnection from the robot.
+        ROBOT_ERROR = 6,          // Represents a robot operation error.
+        SCRIPT_RUNTIME = 10       // Represents a runtime error, such as script execution or syntax issues.
     };
 
     /**

--- a/include/Primary/PrimaryPort.hpp
+++ b/include/Primary/PrimaryPort.hpp
@@ -69,10 +69,11 @@ private:
      * 
      * @param ip The robot ip
      * @param port The port(30001 or 30002)
+     * @param is_last_connect_success Indicate whether the last connection was successful.
      * @return true 
      * @return false 
      */
-    bool socketConnect(const std::string& ip, int port);
+    bool socketConnect(const std::string& ip, int port, bool is_last_connect_success = false);
 
     /**
      * @brief Close connection socket


### PR DESCRIPTION
Fix the issue of frenzied log printing after port 30001 is disconnected; add a callback for unexpected disconnection of port 30001.